### PR TITLE
Sprint 27 TLT-1808 Add request template context processor

### DIFF
--- a/canvas_course_creation/settings/base.py
+++ b/canvas_course_creation/settings/base.py
@@ -74,8 +74,9 @@ TEMPLATES = [
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
-                'django.contrib.auth.context_processors.auth',
                 'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
                 'django.template.context_processors.i18n',
                 'django.template.context_processors.media',
                 'django.template.context_processors.static',


### PR DESCRIPTION
We needed to add `django.template.context_processors.request` to the template context processors, so that the resource link id gets added to the page via django_auth_lti/templates/django_auth_lti/resource_link_id.html.

@eparker71 